### PR TITLE
json fogMode may be null

### DIFF
--- a/com/gamestudiohx/babylonhx/tools/SceneLoader.hx
+++ b/com/gamestudiohx/babylonhx/tools/SceneLoader.hx
@@ -666,8 +666,9 @@ class SceneLoader {
 			scene.gravity = Vector3.FromArray(parsedData.gravity);
 			
 			// Fog
-			if (parsedData.fogMode != 0) {
-				scene.fogMode = parsedData.fogMode;
+			var fogMode : Null<Int> = parsedData.fogMode;
+			if (fogMode != null && fogMode != 0) {
+				scene.fogMode = fogMode;
 				scene.fogColor = Color3.FromArray(parsedData.fogColor);
 				scene.fogStart = parsedData.fogStart;
 				scene.fogEnd = parsedData.fogEnd;


### PR DESCRIPTION
This is a better cross-platform fix, the previous fix gave compiler errors on c++ targets.
