### PR TITLE
post processing bug fixes

### DIFF
--- a/com/babylonhx/_DepthCullingState.hx
+++ b/com/babylonhx/_DepthCullingState.hx
@@ -107,8 +107,9 @@ class _DepthCullingState {
 		this._depthMask = true;
 		this._depthTest = true;
 		this._depthFunc = -1;
-		this._cull = false;
-		this._cullFace = -1;
+		//todo investigate this breaks postprocessing.
+		//this._cull = false;
+		//this._cullFace = -1;
 
 		this._isDepthTestDirty = true;
 		this._isDepthMaskDirty = true;

--- a/com/babylonhx/postprocess/BlurPostProcess.hx
+++ b/com/babylonhx/postprocess/BlurPostProcess.hx
@@ -18,6 +18,9 @@ import com.babylonhx.materials.textures.Texture;
 	
 	public function new(name:String, direction:Vector2, blurWidth:Float, ratio:Float, camera:Camera, samplingMode:Int = 2, ?engine:Engine, reusable:Bool = false/*?reusable:Bool*/) {
 		super(name, "blur", ["screenSize", "direction", "blurWidth"], null, ratio, camera, samplingMode, engine, reusable);
+		this.direction = direction;
+        this.blurWidth = blurWidth;
+        
 		this.onApply = function(effect:Effect) {
 			effect.setFloat2("screenSize", this.width, this.height);
 			effect.setVector2("direction", this.direction);

--- a/com/babylonhx/postprocess/ConvolutionPostProcess.hx
+++ b/com/babylonhx/postprocess/ConvolutionPostProcess.hx
@@ -22,7 +22,7 @@ import  com.babylonhx.materials.Effect;
 	
 	public function new(name:String, kernel:Array<Float>, ratio:Float, camera:Camera, ?samplingMode:Int, ?engine:Engine, reusable:Bool = false/*?reusable:Bool*/) {
 		super(name, "convolution", ["kernel", "screenSize"], null, ratio, camera, samplingMode, engine, reusable);
-
+		this.kernel = kernel;
 		this.onApply = function(effect:Effect) {
 			effect.setFloat2("screenSize", this.width, this.height);
 			effect.setArray("kernel", this.kernel);

--- a/com/babylonhx/postprocess/PostProcess.hx
+++ b/com/babylonhx/postprocess/PostProcess.hx
@@ -72,17 +72,18 @@ import snow.render.opengl.GLTexture;
 		return this._reusable;
 	}
 
-	public function activate(camera:Camera, ?sourceTexture:BabylonTexture):Void {
+	public function activate(camera:Camera, ?sourceTexture:Dynamic):Void {
 		camera = camera != null ? camera : this._camera;
 
 		var scene = camera.getScene();
 		var maxSize = camera.getEngine().getCaps().maxTextureSize;
-		var desiredWidth:Int = cast ((sourceTexture != null ? sourceTexture._width : this._engine.getRenderingCanvas().width) * this._renderRatio);
-		var desiredHeight:Int = cast ((sourceTexture != null ? sourceTexture._height : this._engine.getRenderingCanvas().height) * this._renderRatio);
 
-		desiredWidth = Tools.GetExponantOfTwo(desiredWidth, maxSize);
-		desiredHeight = Tools.GetExponantOfTwo(desiredHeight, maxSize);
+		var desiredWidth = (sourceTexture ? sourceTexture._width : this._engine.getRenderWidth()) * this._renderRatio;
+        var desiredHeight = (sourceTexture ? sourceTexture._height : this._engine.getRenderHeight()) * this._renderRatio;
+        desiredWidth = Tools.GetExponantOfTwo(Std.int(desiredWidth), maxSize);
+		desiredHeight = Tools.GetExponantOfTwo(Std.int(desiredHeight), maxSize);
 
+     
 		if (this.width != desiredWidth || this.height != desiredHeight) {
 			if (this._textures.length > 0) {
 				for (i in 0...this._textures.length) {

--- a/com/babylonhx/postprocess/PostProcessManager.hx
+++ b/com/babylonhx/postprocess/PostProcessManager.hx
@@ -59,9 +59,9 @@ import com.babylonhx.materials.textures.BabylonTexture;
 	}
 
 	public function _finalizeFrame(?doNotPresent:Bool, ?targetTexture:BabylonTexture):Void {
-		var postProcesses = this._scene.activeCamera._postProcesses;
+		var postProcesses:Array<PostProcess> = this._scene.activeCamera._postProcesses;
 		var postProcessesTakenIndices = this._scene.activeCamera._postProcessesTakenIndices;
-		if (postProcessesTakenIndices.length == 0 || !this._scene.postProcessesEnabled) {
+		if (postProcesses.length == 0 || !this._scene.postProcessesEnabled) {
 			return;
 		}
 
@@ -78,13 +78,12 @@ import com.babylonhx.materials.textures.BabylonTexture;
 				}
 			}
 
-			if (doNotPresent != null) {
+			if (doNotPresent) {
 				break;
 			}
-
+			
 			var pp = postProcesses[postProcessesTakenIndices[index]];
 			var effect = pp.apply();
-
 			if (effect != null) {
 				if (pp.onBeforeRender != null) {
 					pp.onBeforeRender(effect);


### PR DESCRIPTION
So it appears that the following is unneeded when reseting:

//todo investigate this breaks postprocessing.
//this._cull = false;
//this._cullFace = -1;

The other examples work the same as they always have.  This will enable postprocess for webGL.  Native platforms have issues with SmartArray I will investigate this soon.  

Bloom and Convolution examples now work. I also noticed that Shadow Map works well on native but is slightly off for webGL.  