### PR TITLE
Instancing support for native openGL

### DIFF
--- a/com/babylonhx/EngineCapabilities.hx
+++ b/com/babylonhx/EngineCapabilities.hx
@@ -1,27 +1,7 @@
 package com.babylonhx;
 
-/**
- * ...
- * @author Krtolica Vujadin
- */
-
-@:expose('BABYLON.EngineCapabilities') class EngineCapabilities {
-	
-	public var maxTexturesImageUnits:Int;
-	public var maxTextureSize:Int;
-	public var maxCubemapTextureSize:Int;
-	public var maxRenderTextureSize:Null<Int>;
-	public var standardDerivatives:Null<Bool>;
-	public var s3tc:Dynamic;
-	public var textureFloat:Null<Bool>;
-	public var textureAnisotropicFilterExtension:Dynamic;
-	public var highPrecisionShaderSupported:Bool;
-	public var maxAnisotropy:Int;
-	public var instancedArrays:Dynamic;
-	public var uintIndices:Null<Bool>;
-	
-	public function new() {
-		
-	}
-	
-}
+#if (js || purejs || html5)
+	typedef EngineCapabilities = com.babylonhx.utils.engineCapabilities.js.EngineCapabilities;
+#else
+	typedef EngineCapabilities = com.babylonhx.utils.engineCapabilities.native.EngineCapabilities;
+#end

--- a/com/babylonhx/utils/engineCapabilities/IGLInstancedArrays.hx
+++ b/com/babylonhx/utils/engineCapabilities/IGLInstancedArrays.hx
@@ -1,0 +1,12 @@
+package com.babylonhx.utils.engineCapabilities;
+
+
+interface IGLInstancedArrays {
+  
+	public dynamic function vertexAttribDivisor (offsetLocations:Array<Int>, divisor:Int):Void;
+
+	public dynamic function drawElementsInstanced (mode:Int, count:Int, type:Int, indices:Int, primcount:Int):Void;
+
+	public dynamic function drawArraysInstanced (mode:Int, first:Int, count:Int, primcount:Int):Void;
+	
+}

--- a/com/babylonhx/utils/engineCapabilities/js/EngineCapabilities.hx
+++ b/com/babylonhx/utils/engineCapabilities/js/EngineCapabilities.hx
@@ -1,0 +1,47 @@
+package com.babylonhx.utils.engineCapabilities.js;
+
+import com.babylonhx.utils.GL;
+
+@:expose('BABYLON.EngineCapabilities') class EngineCapabilities {
+	
+	public var maxTexturesImageUnits:Int;
+	public var maxTextureSize:Int;
+	public var maxCubemapTextureSize:Int;
+	public var maxRenderTextureSize:Null<Int>;
+	public var standardDerivatives:Null<Bool>;
+	public var s3tc:Dynamic;
+	public var textureFloat:Null<Bool>;
+	public var textureAnisotropicFilterExtension:Dynamic;
+	public var highPrecisionShaderSupported:Bool;
+	public var maxAnisotropy:Int;
+	public var instancedArrays:Dynamic;
+	public var uintIndices:Null<Bool>;
+	
+	public function new (supportedExtensions:Array<String>) {
+		this.maxTexturesImageUnits = GL.getParameter(GL.MAX_TEXTURE_IMAGE_UNITS);
+		this.maxTextureSize = GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		this.maxCubemapTextureSize = GL.getParameter(GL.MAX_CUBE_MAP_TEXTURE_SIZE);
+		this.maxRenderTextureSize = GL.getParameter(GL.MAX_RENDERBUFFER_SIZE);
+						
+		// Extensions
+		try {
+			this.standardDerivatives = (GL.getExtension('OES_standard_derivatives') != null);
+			this.s3tc = GL.getExtension('WEBGL_compressed_texture_s3tc');
+			this.textureFloat = (GL.getExtension('OES_texture_float') != null);
+			this.textureAnisotropicFilterExtension = GL.getExtension('EXT_texture_filter_anisotropic') || GL.getExtension('WEBKIT_EXT_texture_filter_anisotropic') || GL.getExtension('MOZ_EXT_texture_filter_anisotropic');
+			this.maxAnisotropy = this.textureAnisotropicFilterExtension != null ? GL.getParameter(this.textureAnisotropicFilterExtension.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 0;
+			this.instancedArrays = new GLInstancedArrays();
+			this.uintIndices = GL.getExtension('OES_element_index_uint') != null;	
+			this.highPrecisionShaderSupported = true;
+			if (GL.getShaderPrecisionFormat != null) {
+				var highp = GL.getShaderPrecisionFormat(GL.FRAGMENT_SHADER, GL.HIGH_FLOAT);
+				this.highPrecisionShaderSupported = highp != null && highp.precision != 0;
+			}
+		} catch (err:Dynamic) {
+			trace("error with javascript engine capabilities");
+			trace(err);
+		}
+		
+	}
+	
+}

--- a/com/babylonhx/utils/engineCapabilities/js/GLInstancedArrays.hx
+++ b/com/babylonhx/utils/engineCapabilities/js/GLInstancedArrays.hx
@@ -1,0 +1,21 @@
+package com.babylonhx.utils.engineCapabilities.js;
+
+import com.babylonhx.utils.GL;
+import com.babylonhx.utils.engineCapabilities.IGLInstancedArrays;
+
+class GLInstancedArrays implements IGLInstancedArrays {
+
+	public function new () {
+		var extension = GL.getExtension('ANGLE_instanced_arrays');
+
+		this.vertexAttribDivisor = extension.vertexAttribDivisorANGLE;
+		this.drawElementsInstanced = extension.drawElementsInstancedANGLE;
+		this.drawArraysInstanced = extension.drawArraysInstancedANGLE;
+	};
+
+	public dynamic function vertexAttribDivisor (offsetLocations:Array<Int>, divisor:Int):Void {}
+
+	public dynamic function drawElementsInstanced (mode, count, type, indices, primcount):Void {}
+
+	public dynamic function drawArraysInstanced (mode, first, count, primcount):Void {}
+}

--- a/com/babylonhx/utils/engineCapabilities/native/EngineCapabilities.hx
+++ b/com/babylonhx/utils/engineCapabilities/native/EngineCapabilities.hx
@@ -1,0 +1,75 @@
+package com.babylonhx.utils.engineCapabilities.native;
+
+import com.babylonhx.utils.GL;
+
+class EngineCapabilities {
+	
+	public var maxTexturesImageUnits:Int;
+	public var maxTextureSize:Int;
+	public var maxCubemapTextureSize:Int;
+	public var maxRenderTextureSize:Null<Int>;
+	public var standardDerivatives:Null<Bool>;
+	public var s3tc:Dynamic;
+	public var textureFloat:Null<Bool>;
+	public var textureAnisotropicFilterExtension:Dynamic;
+	public var highPrecisionShaderSupported:Bool;
+	public var maxAnisotropy:Int;
+	public var instancedArrays:Dynamic;
+	public var uintIndices:Null<Bool>;
+	
+	public function new (supportedExtensions:Array<String>) {
+		this.maxTexturesImageUnits = GL.getParameter(GL.MAX_TEXTURE_IMAGE_UNITS);
+		this.maxTextureSize = GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		this.maxCubemapTextureSize = GL.getParameter(GL.MAX_CUBE_MAP_TEXTURE_SIZE);
+		this.maxRenderTextureSize = GL.getParameter(GL.MAX_RENDERBUFFER_SIZE);
+		
+		// Extensions
+		try {
+			this.standardDerivatives = (GL.getExtension('OES_standard_derivatives') != null);
+			this.s3tc = GL.getExtension('WEBGL_compressed_texture_s3tc');
+			this.textureFloat = (GL.getExtension('OES_texture_float') != null);
+			this.textureAnisotropicFilterExtension = GL.getExtension('EXT_texture_filter_anisotropic') || GL.getExtension('WEBKIT_EXT_texture_filter_anisotropic') || GL.getExtension('MOZ_EXT_texture_filter_anisotropic');
+			this.maxAnisotropy = this.textureAnisotropicFilterExtension != null ? GL.getParameter(this.textureAnisotropicFilterExtension.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 0;
+			this.instancedArrays = new GLInstancedArrays();
+			this.uintIndices = GL.getExtension('OES_element_index_uint') != null;	
+			this.highPrecisionShaderSupported = true;
+			if (GL.getShaderPrecisionFormat != null) {
+				var highp = GL.getShaderPrecisionFormat(GL.FRAGMENT_SHADER, GL.HIGH_FLOAT);
+				this.highPrecisionShaderSupported = highp != null && highp.precision != 0;
+			}
+		} catch (err:Dynamic) {
+			trace(err);
+		}
+
+		if (this.s3tc == null) {
+			this.s3tc = supportedExtensions.indexOf("GL_EXT_texture_compression_s3tc") != -1;
+		}
+		if (this.textureAnisotropicFilterExtension == null || this.textureAnisotropicFilterExtension == false) {
+			
+			this.textureAnisotropicFilterExtension = supportedExtensions.indexOf("GL_EXT_texture_filter_anisotropic") != -1;
+		}
+		if (this.maxRenderTextureSize == 0) {
+			this.maxRenderTextureSize = 16384;
+		}
+		if (this.maxCubemapTextureSize == 0) {
+			this.maxCubemapTextureSize = 16384;
+		}
+		if (this.maxTextureSize == 0) {
+			this.maxTextureSize = 16384;
+		}
+		if (this.uintIndices == null) {
+			this.uintIndices = true;
+		}
+		if (this.standardDerivatives == false) {
+			this.standardDerivatives = true;
+		}
+		if (this.maxAnisotropy == 0) {
+			this.maxAnisotropy = 16;
+		}
+		if (this.textureFloat == false) {
+			this.textureFloat = supportedExtensions.indexOf("GL_ARB_texture_float") != -1;
+		}
+		
+	}
+	
+}

--- a/com/babylonhx/utils/engineCapabilities/native/GLInstancedArrays.hx
+++ b/com/babylonhx/utils/engineCapabilities/native/GLInstancedArrays.hx
@@ -1,0 +1,19 @@
+package com.babylonhx.utils.engineCapabilities.native;
+
+import com.babylonhx.utils.GL;
+import com.babylonhx.utils.engineCapabilities.IGLInstancedArrays;
+
+class GLInstancedArrays implements IGLInstancedArrays{
+	
+	public function new () {
+		this.vertexAttribDivisor = GL.getExtension('glVertexAttribDivisorARB');
+		this.drawElementsInstanced = GL.getExtension('glDrawElementsInstancedARB');
+		this.drawArraysInstanced = GL.getExtension('glDrawArraysInstancedARB');
+	};
+
+	public dynamic function vertexAttribDivisor (offsetLocations:Array<Int>, divisor:Int):Void {}
+
+	public dynamic function drawElementsInstanced (mode, count, type, indices, primcount):Void {}
+
+	public dynamic function drawArraysInstanced (mode, first, count, primcount):Void {}
+}


### PR DESCRIPTION
I have been trying to get instancing to work on native platforms. Tested with lime on windows and html5 targets. This is not yet working. Gives no error but nothing is drawn on the screen either. HTML5 still works. 

The problem I am trying to solve, is that with htlm5 engine uses `ANGLE_instanced_arrays`, which is not available with native OpenGL. Loading of extensions works a bit differently too. You don't load the extension, instead you load a specific function.

My hypothesis is that the api is identical on OpenGL and WebGL (while the extension/function names are different). So to that end I extracted the engine capabilities to different classes and abstracted the instancedArrays implementation so that it loads the correct extension/functions and calls them.

But it is not working. My understanding of OpenGL is pretty much at it's limits, and I was thinking if you might help me so we can get babylonhx instancing  working:)

I also commented a bit of the code inline below.