### PR TITLE
Fix: The aspectRatio getter doesn't work with a dynamic object. It wa…

### DIFF
--- a/com/babylonhx/cameras/Camera.hx
+++ b/com/babylonhx/cameras/Camera.hx
@@ -490,7 +490,8 @@ import com.babylonhx.animations.IAnimatable;
 	}
 
 	private function _getVRProjectionMatrix(force:Bool = false):Matrix {
-		Matrix.PerspectiveFovLHToRef(this._cameraRigParams.vrMetrics.aspectRatioFov, this._cameraRigParams.vrMetrics.aspectRatio, this.minZ, this.maxZ, this._cameraRigParams.vrWorkMatrix);
+        var vrMetrics:VRCameraMetrics = cast this._cameraRigParams.vrMetrics;
+        Matrix.PerspectiveFovLHToRef(vrMetrics.aspectRatioFov, vrMetrics.aspectRatio, this.minZ, this.maxZ, this._cameraRigParams.vrWorkMatrix);
 		this._cameraRigParams.vrWorkMatrix.multiplyToRef(this._cameraRigParams.vrHMatrix, this._projectionMatrix);
 		return this._projectionMatrix;
 	}


### PR DESCRIPTION
…sn't replaced correctly by the compiler and the VR didn't work properly.