### PR TITLE
Changed the samples file, the sample changed names

### DIFF
--- a/src/MainLime.hx
+++ b/src/MainLime.hx
@@ -31,7 +31,7 @@ class MainLime extends Application {
 		engine = new Engine(window, false);	
 		scene = new Scene(engine);
 				
-		//new samples.BasicScene(scene);
+        new samples.BasicScene(scene);
 		//new samples.BasicElements(scene);
 		//new samples.DashedLinesMesh(scene);
 		//new samples.CandleLight(scene);
@@ -107,7 +107,7 @@ class MainLime extends Application {
 		//new samples.WaterMat(scene);
 		//new samples.LavaMat(scene);
 		//new samples.NormalMat(scene);
-		new samples.PythagorianThrees(scene);
+        //new samples.ForestOfPythagoras(scene);
 		//new samples.Particles4(scene);
 		//new samples.MaterialsLibTest(scene);	
 		//new samples.ReflectionProbeTest(scene);

--- a/src/MainSnow.hx
+++ b/src/MainSnow.hx
@@ -25,7 +25,6 @@ class MainSnow extends snow.App {
 		//new samples.BasicScene(scene);
 		//new samples.BasicElements(scene);
 		//new samples.DashedLinesMesh(scene);
-		//new samples.CandleLight(scene);
 		//new samples.RotationAndScaling(scene);
 		//new samples.Materials(scene);
 		//new samples.Lights(scene);
@@ -96,7 +95,7 @@ class MainSnow extends snow.App {
 		//new samples.WaterMat(scene);
 		//new samples.LavaMat(scene);
 		//new samples.NormalMat(scene);
-		new samples.PythagorianThrees(scene);
+        new samples.ForestOfPythagoras(scene);
 		//new samples.Particles4(scene);
 		
 		app.window.onrender = render;


### PR DESCRIPTION
I tried to run the sample, and first thought my setup was broken. That wasn't the case. The sample just didn't exist.

Also on CPP targets on linux (with Haxe 3.2.1) I get this for lime (2.8.2 and 2.8.1) :

```
g++ -o ApplicationMain -rdynamic -m64 @obj/linux64//all_objs -lpthread -ldl -ldl
strip -d ApplicationMain
Engine.hx:168: BabylonHx - Cross-Platform 3D Engine | 2015 | www.babylonhx.com
Effect.hx:235: Unable to compile effect: default
Effect.hx:236: Defines: 
#define LIGHT0
#define HEMILIGHT0

#define NORMAL
#define BonesPerMesh 0
#define NUM_BONE_INFLUENCERS 0

Effect.hx:240: Error #: 0
Effect.hx:241: Error: 
```
Which results in a black window.

And this for snow
```
Engine.hx:168: BabylonHx - Cross-Platform 3D Engine | 2015 | www.babylonhx.com
Effect.hx:235: Unable to compile effect: { fragment => woodtexture, vertex => procedural}
Effect.hx:236: Defines: 
Effect.hx:240: Error #: 0
Effect.hx:241: Error: 0:2(1): error: syntax error, unexpected NEW_IDENTIFIER

Effect.hx:235: Unable to compile effect: { fragment => grasstexture, vertex => procedural}
Effect.hx:236: Defines: 
Effect.hx:240: Error #: 0
Effect.hx:241: Error: 0:2(1): error: syntax error, unexpected NEW_IDENTIFIER

Effect.hx:235: Unable to compile effect: shadowMap
Effect.hx:236: Defines: #define NUM_BONE_INFLUENCERS 0
Effect.hx:240: Error #: 0
Effect.hx:241: Error: 0:2(1): error: syntax error, unexpected NEW_IDENTIFIER

Effect.hx:235: Unable to compile effect: default
Effect.hx:236: Defines: #define AMBIENT

#define LIGHT0
#define SPOTLIGHT0


#define SHADOWS

#define NORMAL
#define UV1
#define BonesPerMesh 0
#define NUM_BONE_INFLUENCERS 0

Effect.hx:240: Error #: 0
Effect.hx:241: Error: 0:14(1): error: syntax error, unexpected NEW_IDENTIFIER

Effect.hx:235: Unable to compile effect: default
Effect.hx:236: Defines: #define DIFFUSE

#define LIGHT0
#define SPOTLIGHT0


#define SHADOWS

#define NORMAL
#define UV1
#define BonesPerMesh 0
#define NUM_BONE_INFLUENCERS 0

Effect.hx:240: Error #: 0
Effect.hx:241: Error: 0:14(1): error: syntax error, unexpected NEW_IDENTIFIER

```
Which also results in a blank black screen program.