### PR TITLE
fix AbstractMesh.rotate() in Space.WORLD issue

### DIFF
--- a/com/babylonhx/mesh/AbstractMesh.hx
+++ b/com/babylonhx/mesh/AbstractMesh.hx
@@ -423,7 +423,7 @@ import com.babylonhx.utils.typedarray.Float32Array;
 				
 				axis = Vector3.TransformNormal(axis, invertParentWorldMatrix);
 			}
-			rotationQuaternion = Quaternion.RotationAxis(axis, amount);
+			var rotationQuaternion = Quaternion.RotationAxis(axis, amount);
 			this.rotationQuaternion = rotationQuaternion.multiply(this.rotationQuaternion);
 		}
 	}


### PR DESCRIPTION
You made a little mistake in the port of the AbstractMesh.rotate() function
Line 426 it is a local rotationQuaternion var that must be declared (and not the rotationQuaternion var from class instance)
Changing this fix the issue with the rotate function when using WORLD Space.