### PR TITLE
Multiple render loop

### DIFF
--- a/com/babylonhx/tools/Tools.hx
+++ b/com/babylonhx/tools/Tools.hx
@@ -50,6 +50,13 @@ typedef Assets = nme.Assets;
 	@:noCompletion public static var app:snow.Snow;
 	#end
 
+	public static function __init__(){
+		#if purejs
+		untyped Browser.window.requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
+													   window.webkitRequestAnimationFrame || window.msRequestAnimationFrame ||
+													   window.oRequestAnimationFrame;
+		#end
+	}
 
 	public static function GetFilename(path:String):String {
 		var index = path.lastIndexOf("/");
@@ -153,6 +160,10 @@ typedef Assets = nme.Assets;
 		}
 		
 		return eventPrefix;
+	}
+
+	public inline static function QueueNewFrame(func:Dynamic->Void):Void {
+		Browser.window.requestAnimationFrame(func);
 	}
 	
 	public static function RegisterTopRootEvents(events:Array<Dynamic>) {

--- a/com/babylonhx/tools/Tools.hx
+++ b/com/babylonhx/tools/Tools.hx
@@ -52,9 +52,11 @@ typedef Assets = nme.Assets;
 
 	public static function __init__(){
 		#if purejs
-		untyped Browser.window.requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
-													   window.webkitRequestAnimationFrame || window.msRequestAnimationFrame ||
-													   window.oRequestAnimationFrame;
+		untyped Browser.window.requestAnimationFrame = window.requestAnimationFrame
+													   || window.mozRequestAnimationFrame
+													   || window.webkitRequestAnimationFrame
+													   || window.msRequestAnimationFrame
+													   || window.oRequestAnimationFrame;
 		#end
 	}
 


### PR DESCRIPTION
Sync BJS about support multiple render loops.

In HTML5, the old implementation was impossible to stop/unset the function set with `runRenderLoop`.
Also, it checks the `requestAnimationFrame` function from all vendors if it doesn't exist.