### PR TITLE
DCE removes multiplyToRef.

### DIFF
--- a/com/babylonhx/cameras/Camera.hx
+++ b/com/babylonhx/cameras/Camera.hx
@@ -505,7 +505,8 @@ import com.babylonhx.animations.Animation;
 
 	private function _getVRProjectionMatrix(force:Bool = false):Matrix {
 		Matrix.PerspectiveFovLHToRef(this._cameraRigParams.vrMetrics.aspectRatioFov(), this._cameraRigParams.vrMetrics.aspectRatio(), this.minZ, this.maxZ, this._cameraRigParams.vrWorkMatrix);
-		this._cameraRigParams.vrWorkMatrix.multiplyToRef(this._cameraRigParams.vrHMatrix, this._projectionMatrix);
+
+		cast(this._cameraRigParams.vrWorkMatrix, Matrix).multiplyToRef(this._cameraRigParams.vrHMatrix, this._projectionMatrix);
 		return this._projectionMatrix;
 	}
 

--- a/com/babylonhx/cameras/TargetCamera.hx
+++ b/com/babylonhx/cameras/TargetCamera.hx
@@ -268,8 +268,8 @@ import com.babylonhx.math.Quaternion;
 		this.position.addToRef(this._transformedReferencePoint, this._currentTarget);
 		
 		Matrix.LookAtLHToRef(this.position, this._currentTarget, this._cameraRigParams.vrActualUp, this._cameraRigParams.vrWorkMatrix);
-		
-		this._cameraRigParams.vrWorkMatrix.multiplyToRef(this._cameraRigParams.vrPreViewMatrix, this._viewMatrix);
+
+		cast(this._cameraRigParams.vrWorkMatrix, Matrix).multiplyToRef(this._cameraRigParams.vrPreViewMatrix, this._viewMatrix);
 		return this._viewMatrix;
 	}
 	


### PR DESCRIPTION
This problem is similar to #76 and #79.

It seems a new DCE error with Haxe 3.3.