### PR TITLE
Fix: Crash if you have a camera with multiple postprocesses.

### DIFF
--- a/com/babylonhx/cameras/Camera.hx
+++ b/com/babylonhx/cameras/Camera.hx
@@ -473,7 +473,8 @@ import com.babylonhx.animations.Animation;
 		}
 		
 		// Postprocesses
-		for (i in 0...this._postProcesses.length) {
+        var i = this._postProcesses.length;
+		while (--i >= 0) {
 			this._postProcesses[i].dispose(this);
 		}
 		

--- a/com/babylonhx/cameras/Camera.hx
+++ b/com/babylonhx/cameras/Camera.hx
@@ -473,7 +473,7 @@ import com.babylonhx.animations.Animation;
 		}
 		
 		// Postprocesses
-        var i = this._postProcesses.length;
+		var i = this._postProcesses.length;
 		while (--i >= 0) {
 			this._postProcesses[i].dispose(this);
 		}


### PR DESCRIPTION
I have multiple postprocesses in my camera and it crashes when the dispose method is called because the index var is out of limits. 

For example, the flow with 2 postprocesses is:

* Camera dispose method is called
  * Postprocess dispose method is called (i = 0, _postProcesses.length=2)
     * Camera detachPostProcess method is called. It deletes one item. So the _postProcesses array is length-1 now.
  * The next postprocess dispose method is called. i=1 and the _postProcesses.length is 1, so it isn't disposed (or it crashes in html5).

I have created a PR in BabylonJS too. https://github.com/BabylonJS/Babylon.js/pull/1598
